### PR TITLE
Enable null models for comdist

### DIFF
--- a/R/comdist.R
+++ b/R/comdist.R
@@ -90,7 +90,7 @@ com_dist <- function(sample, phylo, rand_test = FALSE, null_model = 0, randomiza
 
   if(rand_test == FALSE){
     tmp <- astbl(utils::read.table(text = out, header = TRUE, stringsAsFactors = FALSE))
-    stats::setNames(tmp, c('name', names(tmp)[-1]))
+    names(tmp)[1] = 'name'
   } else {
     tmp <- read.table(text = out, header = FALSE, stringsAsFactors = FALSE)
     # split output into a list of 4 data frames
@@ -107,7 +107,7 @@ com_dist <- function(sample, phylo, rand_test = FALSE, null_model = 0, randomiza
     comdist_null_sd = set_names(tmp[(1 + 2 * n_per_df):(3 * n_per_df), ])
     comdist_NRI = set_names(tmp[(1 + 3 * n_per_df):(4 * n_per_df), ])
     tmp = list(comdist_obs = comdist_obs, comdist_null_mean = comdist_null_mean,
-               comdist_null_sd, comdist_NRI)
+               comdist_null_sd = comdist_null_sd, comdist_NRI = comdist_NRI)
   }
   return(tmp)
 }

--- a/R/comdist.R
+++ b/R/comdist.R
@@ -92,7 +92,7 @@ com_dist <- function(sample, phylo, rand_test = FALSE, null_model = 0, randomiza
     tmp <- astbl(utils::read.table(text = out, header = TRUE, stringsAsFactors = FALSE))
     stats::setNames(tmp, c('name', names(tmp)[-1]))
   } else {
-    tmp <- read.table(text = x, header = FALSE, stringsAsFactors = FALSE)
+    tmp <- read.table(text = out, header = FALSE, stringsAsFactors = FALSE)
     # split output into a list of 4 data frames
     n_per_df = nrow(tmp) / 4
     set_names = function(df){

--- a/R/comdist.R
+++ b/R/comdist.R
@@ -9,7 +9,7 @@
 #' @template phylo
 #' @template com_args
 #' @template com_null_models
-#' @return data.frame
+#' @return data.frame or list if use null models
 #' @examples
 #' sfile <- system.file("examples/sample_comstruct", package = "phylocomr")
 #' pfile <- system.file("examples/phylo_comstruct", package = "phylocomr")
@@ -19,6 +19,7 @@
 #'   stringsAsFactors = FALSE)
 #' phylo_str <- readLines(pfile)
 #' ph_comdist(sample = sampledf, phylo = phylo_str)
+#' #' ph_comdist(sample = sampledf, phylo = phylo_str, rand_test = TRUE)
 #' ph_comdistnt(sample = sampledf, phylo = phylo_str)
 #'
 #' # from files

--- a/man/ph_comdist.Rd
+++ b/man/ph_comdist.Rd
@@ -5,11 +5,11 @@
 \alias{ph_comdistnt}
 \title{comdist}
 \usage{
-ph_comdist(sample, phylo, null_model = 0, randomizations = 999,
-  abundance = TRUE)
+ph_comdist(sample, phylo, rand_test = FALSE, null_model = 0,
+  randomizations = 999, abundance = TRUE)
 
-ph_comdistnt(sample, phylo, null_model = 0, randomizations = 999,
-  abundance = TRUE)
+ph_comdistnt(sample, phylo, rand_test = FALSE, null_model = 0,
+  randomizations = 999, abundance = TRUE)
 }
 \arguments{
 \item{sample}{(data.frame/character) sample data.frame or path to a
@@ -19,6 +19,8 @@ sample file}
 written to a temp file) - OR path to file with a newick
 string - OR a an \pkg{ape} `phylo` object. required.}
 
+\item{rand_test}{(logical) do you want to use null models? Default: FALSE}
+
 \item{null_model}{(integer) which null model to use. See Details.}
 
 \item{randomizations}{(numeric) number of randomizations. Default: 999}
@@ -27,7 +29,7 @@ string - OR a an \pkg{ape} `phylo` object. required.}
 for abundance. Otherwise, uses presence-absence.}
 }
 \value{
-data.frame
+data.frame or a list of data.frame's if use null models
 }
 \description{
 Outputs the phylogenetic distance between samples, based on phylogenetic
@@ -70,6 +72,8 @@ sampledf <- read.table(sfile, header = FALSE,
 phylo_str <- readLines(pfile)
 ph_comdist(sample = sampledf, phylo = phylo_str)
 ph_comdistnt(sample = sampledf, phylo = phylo_str)
+ph_comdist(sample = sampledf, phylo = phylo_str, rand_test = TRUE)
+ph_comdistnt(sample = sampledf, phylo = phylo_str, rand_test = TRUE)
 
 # from files
 sample_str <- paste0(readLines(sfile), collapse = "\\n")
@@ -79,4 +83,6 @@ pfile2 <- tempfile()
 cat(phylo_str, file = pfile2, sep = '\\n')
 ph_comdist(sample = sfile2, phylo = pfile2)
 ph_comdistnt(sample = sfile2, phylo = pfile2)
+ph_comdist(sample = sfile2, phylo = pfile2, rand_test = TRUE)
+ph_comdistnt(sample = sfile2, phylo = pfile2, rand_test = TRUE)
 }

--- a/tests/testthat/test-comdist.R
+++ b/tests/testthat/test-comdist.R
@@ -9,6 +9,7 @@ phylo_str <- readLines(pfile)
 
 test_that("ph_comdist works with data.frame input", {
   aa <- ph_comdist(sample = sampledf, phylo = phylo_str)
+  aa_null <- ph_comdist(sample = sampledf, phylo = phylo_str, rand_test = TRUE)
 
   expect_is(aa, "data.frame")
   expect_named(aa, c('name', 'clump1', 'clump2a', 'clump2b', 'clump4', 'even',
@@ -17,6 +18,18 @@ test_that("ph_comdist works with data.frame input", {
   expect_is(aa$name, "character")
   expect_type(aa$clump1, "double")
   expect_type(aa$even, "double")
+
+  expect_is(aa_null, "list")
+  expect_named(aa_null, c('obs', 'null_mean', 'null_sd', 'NRI_or_NTI'))
+  expect_named(aa_null$obs, c('name', 'clump1', 'clump2a', 'clump2b', 'clump4', 'even',
+                              'random'))
+
+  expect_is(aa_null$obs$name, "character")
+  expect_type(aa_null$obs$clump1, "double")
+  expect_type(aa_null$obs$even, "double")
+  expect_is(aa_null$null_mean$name, "character")
+  expect_type(aa_null$null_sd$clump1, "double")
+  expect_type(aa_null$NRI_or_NTI$even, "double")
 })
 
 test_that("ph_comdist works with file input", {
@@ -27,6 +40,7 @@ test_that("ph_comdist works with file input", {
   cat(phylo_str, file = pfile2, sep = '\n')
 
   aa <- ph_comdist(sample = sfile2, phylo = pfile2)
+  aa_null <- ph_comdist(sample = sfile2, phylo = pfile2, rand_test = TRUE)
 
   expect_is(aa, "data.frame")
   expect_named(aa, c('name', 'clump1', 'clump2a', 'clump2b', 'clump4', 'even',
@@ -35,6 +49,19 @@ test_that("ph_comdist works with file input", {
   expect_is(aa$name, "character")
   expect_type(aa$clump1, "double")
   expect_type(aa$even, "double")
+
+  expect_is(aa_null, "list")
+  expect_named(aa_null, c('obs', 'null_mean', 'null_sd', 'NRI_or_NTI'))
+  expect_named(aa_null$obs, c('name', 'clump1', 'clump2a', 'clump2b', 'clump4', 'even',
+                     'random'))
+
+  expect_is(aa_null$obs$name, "character")
+  expect_type(aa_null$obs$clump1, "double")
+  expect_type(aa_null$obs$even, "double")
+  expect_is(aa_null$null_mean$name, "character")
+  expect_type(aa_null$null_sd$clump1, "double")
+  expect_type(aa_null$NRI_or_NTI$even, "double")
+
 })
 
 
@@ -42,9 +69,15 @@ test_that("ph_comdist - different models give expected output", {
   n0 <- ph_comdist(sample = sfile, phylo = pfile, null_model = 0)
   n1 <- ph_comdist(sample = sfile, phylo = pfile, null_model = 1)
 
+  n0_null <- ph_comdist(sample = sfile, phylo = pfile, rand_test = TRUE, null_model = 0)
+  n1_null <- ph_comdist(sample = sfile, phylo = pfile, rand_test = TRUE, null_model = 1)
+
   # identical
   expect_identical(n0$clump1, n1$clump1)
   expect_identical(n0$clump4, n1$clump4)
+
+  expect_identical(n0$clump1, n0_null$obs$clump1)
+  expect_identical(n1$clump1, n1_null$obs$clump1)
 })
 
 test_that("ph_comdist fails well", {
@@ -57,6 +90,8 @@ test_that("ph_comdist fails well", {
                "sample must be of class character, data.frame")
   expect_error(ph_comdist("adf", mtcars),
                "phylo must be of class character, phylo")
+  expect_error(ph_comdist(sfile, pfile, rand_test = 5),
+               "rand_test must be of class logical")
   expect_error(ph_comdist(sfile, pfile, null_model = mtcars),
                "null_model must be of class numeric, integer")
   expect_error(ph_comdist(sfile, pfile, randomizations = mtcars),


### PR DESCRIPTION
Phylocom requires `-n` option to enable null models, with the default of **not** using null models. Therefore, without `-n`, it won't run null models even with `-r` options.