### PR TITLE
Fix GCC 10 warning about global variables

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -2,7 +2,7 @@ INSTDIR=../inst/bin${R_ARCH}
 LIBPHYLOCOM=libphylocom/io.o libphylocom/new2fy.o  libphylocom/traits.o \
 	libphylocom/comstruct.o libphylocom/nrutil.o libphylocom/fy2new.o libphylocom/bladj.o \
 	libphylocom/comnode.o libphylocom/prune.o libphylocom/comtrait.o libphylocom/stats.o \
-	libphylocom/combase.o libphylocom/globals.o
+	libphylocom/combase.o
 
 # Debugging flag
 # PKG_CFLAGS = -fno-common

--- a/src/Makevars
+++ b/src/Makevars
@@ -2,30 +2,31 @@ INSTDIR=../inst/bin${R_ARCH}
 LIBPHYLOCOM=libphylocom/io.o libphylocom/new2fy.o  libphylocom/traits.o \
 	libphylocom/comstruct.o libphylocom/nrutil.o libphylocom/fy2new.o libphylocom/bladj.o \
 	libphylocom/comnode.o libphylocom/prune.o libphylocom/comtrait.o libphylocom/stats.o \
-	libphylocom/combase.o
+	libphylocom/combase.o libphylocom/globals.o
 
 # Debugging flag
-# PKG_CFLAGS = -Wno-unused
+# PKG_CFLAGS = -fno-common
+STATLIB = libphylocom/libphylocom.a
 
 all: clean executables
 
 executables: phylocom ecovolve phylomatic
 
-libphylocom.a: $(LIBPHYLOCOM)
+$(STATLIB): $(LIBPHYLOCOM)
 	mkdir -p $(INSTDIR)
-	$(AR) rcs libphylocom.a $(LIBPHYLOCOM)
+	$(AR) rcs $(STATLIB) $(LIBPHYLOCOM)
 
-phylocom: libphylocom.a libphylocom/main.o
-	$(CC) $(CPPFLAGS) $(CFLAGS) -o phylocom libphylocom/main.o -L. -lphylocom -lm
+phylocom: $(STATLIB) libphylocom/main.o
+	$(CC) $(CPPFLAGS) $(CFLAGS) -o phylocom libphylocom/main.o -Llibphylocom -lphylocom -lm
 	cp -f phylocom $(INSTDIR)
 
-ecovolve: libphylocom.a libphylocom/ecomain.o
-	$(CC) $(CPPFLAGS) $(CFLAGS) -o ecovolve libphylocom/ecomain.o -L. -lphylocom -lm
+ecovolve: $(STATLIB) libphylocom/ecomain.o
+	$(CC) $(CPPFLAGS) $(CFLAGS) -o ecovolve libphylocom/ecomain.o -Llibphylocom -lphylocom -lm
 	cp -f ecovolve $(INSTDIR)
 
-phylomatic: libphylocom.a libphylocom/phylomatic.o
-	$(CC) $(CPPFLAGS) $(CFLAGS) -o phylomatic libphylocom/phylomatic.o -L. -lphylocom -lm
+phylomatic: $(STATLIB) libphylocom/phylomatic.o
+	$(CC) $(CPPFLAGS) $(CFLAGS) -o phylomatic libphylocom/phylomatic.o -Llibphylocom -lphylocom -lm
 	cp -f phylomatic $(INSTDIR)
 
 clean:
-	rm -Rf $(OBJECTS) libphylocom/*.o libphylocom.a phylocom ecovolve phylomatic
+	rm -Rf $(SHLIB) $(OBJECTS) $(LIBPHYLOCOM) $(STATLIB) phylocom ecovolve phylomatic

--- a/src/libphylocom/ecomain.c
+++ b/src/libphylocom/ecomain.c
@@ -1,5 +1,5 @@
 /*  ecomain.c  */
-
+#include "globals.c"
 #include "ecovolve.h"
 #include "nrutil.h"
 

--- a/src/libphylocom/ecomain.c
+++ b/src/libphylocom/ecomain.c
@@ -1,11 +1,5 @@
 /*  ecomain.c  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <math.h>
-#include <string.h>
-#include <sys/types.h>
-#include <unistd.h>
 #include "ecovolve.h"
 #include "nrutil.h"
 
@@ -29,11 +23,11 @@ int main(int argc, char *argv[])
 
   PRUNED = 0;
   Droptail = 0;
- 
-  setbuf(stdout, NULL);  
+
+  setbuf(stdout, NULL);
   // srandom(time(NULL));
   //srandom(2);
-  srandom(getpid()); // need this because in a shell-script the program 
+  srandom(getpid()); // need this because in a shell-script the program
   // may run several times
 
   MAX_TIME = MAXTIME;
@@ -51,11 +45,11 @@ int main(int argc, char *argv[])
       if (strcmp(argv[argx], "-e") == 0)
         {
           sscanf(argv[argx+1], "%f", &p_EXTINCT);
-        }      
+        }
       if (strcmp(argv[argx], "-t") == 0)
         {
           sscanf(argv[argx+1], "%d", &MAX_TIME);
-        } 
+        }
       if (strcmp(argv[argx], "-d") == 0)
         {
           TAPER = 1;
@@ -133,7 +127,7 @@ int main(int argc, char *argv[])
           Censor_lt[l][t] = 0;
         }
     }
-    
+
   // initialize starting lineage
   Node = 0; // AHA A problem here!!!! switch to 0 must change later
   Lineage = 0;
@@ -157,11 +151,11 @@ int main(int argc, char *argv[])
   t = 0;
   while (stop == 0)
     {
-      
+
       // Determine competitive effect on extinction (before new evolution
       // and speciation)  simplest model - distance to nearest phenotype
       Compete(t);
-                        
+
       // store the last lineage number, so that it doesnt get confused by new species
       ll = Lineage;
 
@@ -181,7 +175,7 @@ int main(int argc, char *argv[])
               // vvv EDIT HERE FOR COMPETITION ALG vvv
               if (COMPETE)
                 {
-                  // the modified extinction probability is 
+                  // the modified extinction probability is
                   newp_EXTINCT = p_EXTINCT * (5.0 / ((float) EcoDist_l[l] \
                                                      + 1.0));
                   // printf("%f\n",newp_EXTINCT);
@@ -199,7 +193,7 @@ int main(int argc, char *argv[])
                 {
                   Speciate(l, t);
                   alive++;
-          
+
                 }
 
               // check for extinction, if the lineage has not speciated,
@@ -234,7 +228,7 @@ int main(int argc, char *argv[])
   //fprintf(stderr, "time: %d, lineages: %d, ", t, alive);
   tout = t; aliveout = alive;
 
-  // for those lineages still alive, kill em all! 
+  // for those lineages still alive, kill em all!
   //(thus giving them nodes & names)
   for (l = 0; l <= Lineage; l++)
     {
@@ -300,13 +294,13 @@ int main(int argc, char *argv[])
             }
         }
       // Calculate Char Variance
-      
+
       for (chi = 0; chi < NCHAR; chi++)
         {
           CharSumXSqr[chi] = ( CharSumXSqr[chi] - ( ( CharMean[chi] * CharMean[chi]) / \
                                                     (float) LttZ ) ) / (float) (LttZ - 1);
           CharMean[chi] = CharMean[chi] / (float) LttZ;
-      
+
           CharCSumXSqr[chi] = ( CharCSumXSqr[chi] - ( ( CharCMean[chi] * CharCMean[chi]) / \
                                                       (float) LttC ) ) / (float) (LttC - 1);
           CharCMean[chi] = CharCMean[chi] / (float) LttC;
@@ -314,18 +308,18 @@ int main(int argc, char *argv[])
       // output LTT
       if (OUT_MODE == 2) printf("%d\t%d\t%6.1f\t%6.1f\t%d\t%6.1f\t%6.1f\n", t, LttZ, \
                                 CharMean[0], CharSumXSqr[0], LttC, CharCMean[0], CharCSumXSqr[0]);
-            
+
       // Print out
     }
 
-  if (OUT_MODE == 3) 
+  if (OUT_MODE == 3)
     {
       MakePhylo();
       fprintf(stderr, ", time: %d, lineages: %d\n", tout, aliveout);
       WriteTraits();
       DummySample();
     }
-    
+
   return 1;
 }
 
@@ -343,15 +337,15 @@ void Speciate(int l, int t)
 
   // what's the node above it?
   NodeUp_n[Node] = NodeUp_l[l];
-  
+
   // what's the BL?
   BlUp_n[Node] = t - Time_n[NodeUp_n[Node]];
-  
+
   // The Char value?
   for (chi = 0; chi < NCHAR; chi++)
     {
       Char_nc[Node][chi] = Char_ltc[l][t][chi];
-    }  
+    }
   // make new lineages (can add polytomies)
   for (x = 0; x <=1; x++)
     {
@@ -365,11 +359,11 @@ void Speciate(int l, int t)
           Char_ltc[Lineage][t+1][chi] = Char_ltc[l][t][chi];
         }
     }
-  
+
   // deactivate current lineage
   Active_l[l] = 0;
   Living_lt[l][t+1] = 0;
-    
+
   // see it:
   Output(t);
 }
@@ -380,7 +374,7 @@ void CharChange(int l, int t)
 {
   int change, i;
   // int amount[17] = {-3,-2,-1,-1,-1,0,0,0,0,0,0,0,1,1,1,2,3};
-  // change = (int) ((17.0 * (float) random()) /    
+  // change = (int) ((17.0 * (float) random()) /
   //          (float) (RAND_MAX+1.0));
 
   for(i = 0; i < NCHAR; i++)
@@ -390,7 +384,7 @@ void CharChange(int l, int t)
 
       // printf("change = %d, n = %d\n", change, charch.n);
       //if (OUT_MODE == 0) printf("change = %d\n", change);
-  
+
       if (TAPER)
         {
           Char_ltc[l][t][i] = Char_ltc[l][t][i] + \
@@ -403,7 +397,7 @@ void CharChange(int l, int t)
         }
       // record max and min
       if (CharMin[i] > Char_ltc[l][t][i]) CharMin[i] = Char_ltc[l][t][i];
-      if (CharMax[i] < Char_ltc[l][t][i]) CharMax[i] = Char_ltc[l][t][i];       
+      if (CharMax[i] < Char_ltc[l][t][i]) CharMax[i] = Char_ltc[l][t][i];
     }
 }
 
@@ -437,7 +431,7 @@ void Extinct(int l, int t)
 {
   int chi;
   // make a new node
-  Node++;   
+  Node++;
   Time_n[Node] = t;
   Name++;
   Name_n[Node] = Node;
@@ -450,7 +444,7 @@ void Extinct(int l, int t)
 
   // what's the node above it?
   NodeUp_n[Node] = NodeUp_l[l];
-  
+
   // what's the BL?
   BlUp_n[Node] = t - Time_n[NodeUp_n[Node]];
 
@@ -467,11 +461,11 @@ void Output(int t)
   if (OUT_MODE == 0)
     printf("EVENT t %d\t\tn %d\tu %d\tb %d\t' %d\tc %f\n", t, Node, NodeUp_n[Node], \
            BlUp_n[Node], Name_n[Node], Char_nc[Node][0]);
-  
+
   if (OUT_MODE == 1) printf("%d\t%d\t%d\t%d\t%f\t%d\n", Node, NodeUp_n[Node], \
                             BlUp_n[Node], Name_n[Node], Char_nc[Node][0], Time_n[Node]);
 
-  
+
 }
 
 void MakePhylo()
@@ -496,14 +490,14 @@ void MakePhylo()
   OutTree.depth[0] = 0;
 
   for (x = 1; x <= Node; x++)
-    { 
+    {
 
       if (Terminal_n[x] == 1) prunex[x-1] = 1;
       else prunex[x-1] = 0;
 
       OutTree.up[x-1] = NodeUp_n[x]-1;
       OutTree.bl[x-1] = (float) BlUp_n[x];
-      
+
       if (Terminal_n[x] == 0) sprintf(tmp, "node%d", Name_n[x]-1);
       if (Terminal_n[x] == 1) sprintf(tmp, "sp%d", Name_n[x]-1);
       if (Terminal_n[x] == 2) sprintf(tmp, "dead%d", Name_n[x]-1);
@@ -521,7 +515,7 @@ void MakePhylo()
   //printf("nnodes = %d\n",OutTree.nnodes);
 
   //  for (x = 0; x < OutTree.nnodes; x++)
-  //  { 
+  //  {
   //      printf("%d\t%d\t%d\t%f\t%d\t%s\n", x, OutTree.up[x], OutTree.depth[x], OutTree.bl[x], OutTree.noat[x], OutTree.taxon[x]);
 
   //  }
@@ -530,19 +524,19 @@ void MakePhylo()
   else Fy2newRec(OutTree);
 
   // Balance
-  if (PRUNED == 1 ) 
+  if (PRUNED == 1 )
     {
       fprintf(stderr, "balance: %f", Balance(Prune(OutTree, prunex)));
     }
-  else 
+  else
     {
-      for (x = 0; x < OutTree.nnodes; x++) 
+      for (x = 0; x < OutTree.nnodes; x++)
         {
           if (OutTree.noat[x]==0) prunex[x] = 1;
           else prunex[x] = 0;
         }
       fprintf(stderr, "balance: %f", Balance(Prune(OutTree, prunex)));
-    }  
+    }
 
 }
 
@@ -560,11 +554,11 @@ shift MakeChange(char brownian[11])
   for (x = 0; x < 10; x++)
     {
       strncpy(tmp, &brownian[x],1);
-      sscanf(tmp, "%d", &brownvec[x]); 
+      sscanf(tmp, "%d", &brownvec[x]);
       if (x == 0) brownsum0 += brownvec[x];
       if (x > 0) brownsum1 += brownvec[x];
     }
-  
+
   brown.n = brownsum1 + brownsum0 + brownsum1;
 
   //  printf("length = %d\n",  (brownsum1 + brownsum0 + brownsum1));
@@ -605,7 +599,7 @@ void WriteTraits()
   FILE *out_file;
 
   if ( (out_file = fopen("ecovolve.traits", "w") ) == NULL )
-    {   
+    {
       fprintf(stderr, "Error: cannot write to file ecovolve.traits\n");
       exit(8);
     }
@@ -661,7 +655,7 @@ void DummySample()
   FILE *out_file;
 
   if ( (out_file = fopen("ecovolve.sample", "w") ) == NULL )
-    {   
+    {
       fprintf(stderr, "Error: cannot write to file ecovolve.sample\n");
       exit(8);
     }
@@ -683,7 +677,7 @@ float Balance(struct phylo A)
   int *nsub;
   int dev;
   float sumBal = 0.0;
-  
+
   nsub = ivector(0, A.nnodes);
 
   for (i = 0; i < A.nnodes; i++)
@@ -702,7 +696,7 @@ float Balance(struct phylo A)
             }
         }
     }
-  
+
   k = 0; nterm=0;
   for (i = 0; i < A.nnodes; i++)
     {

--- a/src/libphylocom/ecovolve.h
+++ b/src/libphylocom/ecovolve.h
@@ -51,7 +51,8 @@
 #include <stdio.h>
 #include <math.h>  // for sqrt()
 #include <stdlib.h>
-#include "phylocom.h"
+#include <sys/types.h>
+#include <unistd.h>
 
 /* DEFINITIONS FOR MAIN PROGRAM ------------------------------------------ */
 

--- a/src/libphylocom/globals.c
+++ b/src/libphylocom/globals.c
@@ -1,0 +1,47 @@
+/* GLOBAL VARIABLES ------------------------------------------------------ */
+// Capital first letter for global variables (generally)
+// small first letters for internal vars
+#include "phylocom.h"
+
+FILE *Fp;   // pointer to phylo
+FILE *Fn;   // pointer to phylo.new
+FILE *Ft;   // pointer to sample
+FILE *Fm;   // pointer to means
+FILE *Fc;   // pointer to traits
+FILE *Fa;   // pointer to age file
+
+char PhyloFile[50]; // default name
+char SampleFile[50]; // default name
+char TraitFile[50]; // default name
+//int UseFy; // switch for using .fy format input
+int NoBL; // switch for ignoring branch lenghts
+int Droptail; // switch for dropping the root tail
+int FYOUT; // switch for outputting as fy format
+
+int RUNS, TRAITS, SWAPS, XVAR, AOTOUT, SWAPMETHOD, RNDPRUNEN, RNDPRUNET, MAKENODENAMES, NULLTESTING;
+long BURNIN;
+int Debug;
+int Verbose;
+float HILEVEL;
+int LowSig; // global switch for low vs. high one-tailed sig testing
+int UseAbund; //use abundance data when available?
+int FYOUT; // Output to fy format
+
+
+// Sorting params, passed from RemoveDups to Shuffle
+int TaxaOrder[MAXTAXA+1]; // sp code<1> of the nth ordered taxon<1>
+int FirstSingleton, LastSingleton; // the rank<1> of the first/last single
+
+// counters used in main, passed to functions
+int Select;       // subset to use
+int Sample;       //  The plot (or Sample) counter
+int PlotsUsed;    //  The number of plots used, that exceed MINIMUM
+char Method[20]; // type of analysis
+int TreeView; //TODO fix this and related NodeSig function
+
+// DDA:
+// trait Values
+float **Char;
+int *CharType; //0 = binary; 1 = multistate; 2 = ordered multistate; 3 = continuous // CW changed 9apr04
+// trait conservatism
+//int **RndArr;

--- a/src/libphylocom/main.c
+++ b/src/libphylocom/main.c
@@ -1,4 +1,4 @@
-#include "phylocom.h"
+#include "globals.c"
 #include "nrutil.h"
 
 int main(int argc, char *argv[])

--- a/src/libphylocom/main.c
+++ b/src/libphylocom/main.c
@@ -1,8 +1,3 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <math.h>
-#include <string.h>
-#include <time.h>
 #include "phylocom.h"
 #include "nrutil.h"
 

--- a/src/libphylocom/phylocom.h
+++ b/src/libphylocom/phylocom.h
@@ -231,29 +231,29 @@ void RaoDiversity();
 // Capital first letter for global variables (generally)
 // small first letters for internal vars
 
-FILE *Fp;   // pointer to phylo
-FILE *Fn;   // pointer to phylo.new
-FILE *Ft;   // pointer to sample
-FILE *Fm;   // pointer to means
-FILE *Fc;   // pointer to traits
-FILE *Fa;   // pointer to age file
+extern FILE *Fp;   // pointer to phylo
+extern FILE *Fn;   // pointer to phylo.new
+extern FILE *Ft;   // pointer to sample
+extern FILE *Fm;   // pointer to means
+extern FILE *Fc;   // pointer to traits
+extern FILE *Fa;   // pointer to age file
 
-char PhyloFile[50]; // default name
-char SampleFile[50]; // default name
-char TraitFile[50]; // default name
+extern char PhyloFile[50]; // default name
+extern char SampleFile[50]; // default name
+extern char TraitFile[50]; // default name
 //int UseFy; // switch for using .fy format input
-int NoBL; // switch for ignoring branch lenghts
-int Droptail; // switch for dropping the root tail
-int FYOUT; // switch for outputting as fy format
+extern int NoBL; // switch for ignoring branch lenghts
+extern int Droptail; // switch for dropping the root tail
+extern int FYOUT; // switch for outputting as fy format
 
-int RUNS, TRAITS, SWAPS, XVAR, AOTOUT, SWAPMETHOD, RNDPRUNEN, RNDPRUNET, MAKENODENAMES, NULLTESTING;
-long BURNIN;
-int Debug;
-int Verbose;
-float HILEVEL;
-int LowSig; // global switch for low vs. high one-tailed sig testing
-int UseAbund; //use abundance data when available?
-int FYOUT; // Output to fy format
+extern int RUNS, TRAITS, SWAPS, XVAR, AOTOUT, SWAPMETHOD, RNDPRUNEN, RNDPRUNET, MAKENODENAMES, NULLTESTING;
+extern long BURNIN;
+extern int Debug;
+extern int Verbose;
+extern float HILEVEL;
+extern int LowSig; // global switch for low vs. high one-tailed sig testing
+extern int UseAbund; //use abundance data when available?
+extern int FYOUT; // Output to fy format
 
 typedef struct nodes {
 	float ***tCh; // tip based character stats
@@ -335,19 +335,19 @@ typedef struct means {
 } means;
 
 // Sorting params, passed from RemoveDups to Shuffle
-int TaxaOrder[MAXTAXA+1]; // sp code<1> of the nth ordered taxon<1>
-int FirstSingleton, LastSingleton; // the rank<1> of the first/last single
+extern int TaxaOrder[MAXTAXA+1]; // sp code<1> of the nth ordered taxon<1>
+extern int FirstSingleton, LastSingleton; // the rank<1> of the first/last single
 
 // counters used in main, passed to functions
-int Select;       // subset to use
-int Sample;       //  The plot (or Sample) counter
-int PlotsUsed;    //  The number of plots used, that exceed MINIMUM
-char Method[20]; // type of analysis
-int TreeView; //TODO fix this and related NodeSig function
+extern int Select;       // subset to use
+extern int Sample;       //  The plot (or Sample) counter
+extern int PlotsUsed;    //  The number of plots used, that exceed MINIMUM
+extern char Method[20]; // type of analysis
+extern int TreeView; //TODO fix this and related NodeSig function
 
 // DDA:
 // trait Values
-float **Char;
-int *CharType; //0 = binary; 1 = multistate; 2 = ordered multistate; 3 = continuous // CW changed 9apr04
+extern float **Char;
+extern int *CharType; //0 = binary; 1 = multistate; 2 = ordered multistate; 3 = continuous // CW changed 9apr04
 // trait conservatism
 //int **RndArr;

--- a/src/libphylocom/phylomatic.c
+++ b/src/libphylocom/phylomatic.c
@@ -38,17 +38,11 @@
 
 /* INCLUDE HEADERS ------------------------------------------------------- */
 
-#include <stdio.h>
-#include <math.h>
-#include <stdlib.h>
-#include <string.h>
 #include <ctype.h>
 #include "phylocom.h"
 #include "nrutil.h"
 
 int LOWERCASETAXA = 0;
-int Droptail = 1;  // no root tails from phylomatic
-int FYOUT = 0;
 
 struct taxa ReadTaxa();
 
@@ -79,7 +73,7 @@ int main(int argc, char *argv[])
   Debug = 0;
 
   // set the buffer to zero, so output is written directly to file:
-  setbuf(stdout, NULL);  
+  setbuf(stdout, NULL);
 
   // pick up the global switches:
   for (argx = 0; argx <  argc; argx++)
@@ -160,9 +154,9 @@ int main(int argc, char *argv[])
       strcpy(P.taxalist[i], M.taxalist[i]);
       P.t2n[i] = M.t2n[i];
     }
-  
+
   matched = ivector(0, T.ntx-1); for (i=0;i<T.ntx;i++) matched[i]=0;
-  keep    = ivector(0, P.nnodes -1); 
+  keep    = ivector(0, P.nnodes -1);
   for (i=0;i<P.nnodes;i++) keep[i]=0;
   next = M.nnodes;
   nexttl = M.ntaxa;
@@ -178,7 +172,7 @@ int main(int argc, char *argv[])
             {
               for (k = 0; k < next; k++) // looping through all nodes
                 {
-                  // ---- compare with the taxon name at every node in the 
+                  // ---- compare with the taxon name at every node in the
                   // ---- megatree
                   if (strcmp(T.str[i][j], P.taxon[k]) == 0)
                     {
@@ -257,10 +251,10 @@ int main(int argc, char *argv[])
                       break;
                     }
                 }
-            } 
+            }
         }
     }
-  
+
   if (Debug)
     {
       for (i = 0; i < P.nnodes; i++)
@@ -273,7 +267,7 @@ int main(int argc, char *argv[])
 
   if (FYOUT) FyOut(Prune(P, keep)) ;
   else Fy2newRec(Prune(P, keep));
-  
+
   // Missing taxa
   if (nmatched < T.ntx)
     {
@@ -339,12 +333,12 @@ struct taxa ReadTaxa(char filename[100])
   T.ntx = linesread;
   T.maxnest = maxslash+1;
   T.str = c3d(0, T.ntx-1, 0, T.maxnest-1, 0, MAXTAXONLENGTH);
-  
+
   // initialize - important!
   for (i = 0; i < T.ntx; i++) {
     for (j =  0; j < T.maxnest; j++) {
       strcpy(T.str[i][j], ""); } }
- 
+
   // now read:
   linesread = 0;
   taxafile = fopen(filename, "r");
@@ -354,7 +348,7 @@ struct taxa ReadTaxa(char filename[100])
       i = (int) strlen(line) - 2; // not the newline
 
       // Convert to lowercase
-      if (LOWERCASETAXA) 
+      if (LOWERCASETAXA)
         {
           for (k = 0; k < strlen(line); k++) line[k] = tolower(line[k]);
         }
@@ -364,7 +358,7 @@ struct taxa ReadTaxa(char filename[100])
       k = 0;
       while (i >= -1) // newline
         {
-          if ((line[i] == 47) || (i == -1) ) 
+          if ((line[i] == 47) || (i == -1) )
             {
               strncat(T.str[linesread][k], &line[i+1], j-i);
               i--;

--- a/src/libphylocom/phylomatic.c
+++ b/src/libphylocom/phylomatic.c
@@ -39,7 +39,7 @@
 /* INCLUDE HEADERS ------------------------------------------------------- */
 
 #include <ctype.h>
-#include "phylocom.h"
+#include "globals.c"
 #include "nrutil.h"
 
 int LOWERCASETAXA = 0;


### PR DESCRIPTION
To reproduce the problem on Mac, add a line with:

```
CFLAGS += -pedantic -fno-common
```
to your `~/.R/Makevars` (in your home directory). You should see an error with the cran version.