### PR TITLE
avoiding -Wstringop-truncation warning

### DIFF
--- a/src/libphylocom/io.c
+++ b/src/libphylocom/io.c
@@ -769,6 +769,7 @@ traits ReadTraits(char traitfile[50])
   struct traits C;
   FILE *Cread;
   char line[MAXTRAITLINE];
+  char tiny[2];
   int i, j, waitingforspace;
   int nline, words;
   int extra = 0;
@@ -776,6 +777,7 @@ traits ReadTraits(char traitfile[50])
   char tmp[MAXTAXONLENGTH + 6];
   int lineending;
 
+  tiny[1] = '\0';
   C.ntaxa = 0;
   C.ntraits = 0;
 
@@ -815,7 +817,9 @@ traits ReadTraits(char traitfile[50])
                 }
               else
                 {
-                  strncat(word[words] , &line[i], 1);
+                  // strncat(word[words] , &line[i], 1);
+                  tiny[0] = line[i];
+                  strncat(word[words] , tiny, 2);
                   waitingforspace = 1;
                 }
             }
@@ -865,7 +869,9 @@ traits ReadTraits(char traitfile[50])
             }
           else
             {
-              strncat(word[words] , &line[i], 1);
+              // strncat(word[words] , &line[i], 1);
+              tiny[0] = line[i];
+              strncat(word[words] , tiny, 2);
               waitingforspace = 1;
             }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
copying char to tmp string "tiny" to avoid warning making CRAN mad

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
